### PR TITLE
Simplify iteration in extract_metrics.py

### DIFF
--- a/extract_metrics.py
+++ b/extract_metrics.py
@@ -5,6 +5,6 @@ tcx_file = TCXFile()
 all_files = tcx_file.read_directory('/var/ds/tcx-test-files/running')
 
 # iterate through files and print total distance of activities
-for i in range(len(all_files)):
-    activity = tcx_file.read_one_file(all_files[i])
+for path in all_files:
+    activity = tcx_file.read_one_file(path)
     print('total distance: ', activity['total_distance'] / 1000)


### PR DESCRIPTION
Instead of iterating over indices C-style, iterate directly over the list of paths, which is simpler and is the “Pythonic” way to do it.